### PR TITLE
Updating Android-gif-drawable to 1.2.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The native libraries used to handle rendering GIFs for Android & iOS.
     <Gif:Gif headers="{{headersJSON}}" src="~/gifs/bill.gif" height="100" />
     <Gif:Gif src="https://media4.giphy.com/media/3uyIgVxP1qAjS/200.gif" height="200" />
   </StackLayout>
-</Page>  
+</Page>
 ```
 
 #### Angular NativeScript
@@ -136,3 +136,7 @@ registerElement("Gif", () => Gif);
 ##### recycle()
 
 * provided to speed up freeing memory <small>_advanced usage - you shouldn't need this often_</small>
+
+#### Contributors
+- [NathanaelA](https://github.com/NathanaelA) - [@CongoCart](https://twitter.com/CongoCart)
+- [NathanWalker](https://github.com/NathanWalker) - [@wwwalkerrun](https://twitter.com/wwwalkerrun)

--- a/src/package.json
+++ b/src/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nativescript-gif",
+  "name": "digitaltown-nativescript-gif",
   "version": "4.0.1",
   "description": "NativeScript plugin to use .gifs",
   "main": "gif",

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -1,6 +1,6 @@
 //default elements
 android {
-    
+
 }
 
 repositories {
@@ -8,5 +8,5 @@ repositories {
 }
 
 dependencies {
-    compile 'pl.droidsonroids.gif:android-gif-drawable:1.2.14'
+    compile 'pl.droidsonroids.gif:android-gif-drawable:1.2.15'
 }


### PR DESCRIPTION
## Update android-gif-drawable 1.2.15
This prevents Android Kitkat and below from crashing

As mentioned in this issue:
https://github.com/bradmartin/nativescript-gif/issues/25