### PR TITLE
Updating Android-gif-drawable to 1.2.15

### DIFF
--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -1,6 +1,6 @@
 //default elements
 android {
-    
+
 }
 
 repositories {
@@ -8,5 +8,5 @@ repositories {
 }
 
 dependencies {
-    compile 'pl.droidsonroids.gif:android-gif-drawable:1.2.14'
+    compile 'pl.droidsonroids.gif:android-gif-drawable:1.2.15'
 }


### PR DESCRIPTION
## Update android-gif-drawable 1.2.15
This prevents Android Kitkat and below from crashing

As mentioned in this issue:
https://github.com/bradmartin/nativescript-gif/issues/25