### PR TITLE
Fix TS typings getting removed in npm build

### DIFF
--- a/src/.npmignore
+++ b/src/.npmignore
@@ -33,7 +33,7 @@ node_modules/
 *.gz
 *.zip
 
-!index.d.ts
+!gif.d.ts
 
 references.d.ts
 tsconfig.json


### PR DESCRIPTION
Newer versions don't have the TS typings anymore which makes the plugin unusable when using typescript.
This fixes it by fixing the exclusion in the npmignore file as discussed on Slack.